### PR TITLE
KA2-9 - Create a relational database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # elision-internship-backend
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rodzers-usackis_elision-internship-backend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rodzers-usackis_elision-internship-backend)
+
 Backend Repository For The Elision Internship Project

--- a/relational_database/create_tables.sql
+++ b/relational_database/create_tables.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE application_user (
+                      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                      first_name VARCHAR(50) NOT NULL,
+                      last_name VARCHAR(50) NOT NULL,
+                      password VARCHAR(20) NOT NULL
+);
+
+INSERT INTO application_user (id, first_name, last_name, password)
+VALUES (uuid_generate_v4(), 'John', 'Doe', 'password');

--- a/relational_database/create_users.sh
+++ b/relational_database/create_users.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+POSTGRES_USER=postgres
+POSTGRES_DB=relational_database
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER rodzers WITH PASSWORD 'rodzerspassword';
+    CREATE USER dominik WITH PASSWORD 'dominikpassword';
+    CREATE USER test WITH PASSWORD 'testpassword';
+    REVOKE ALL ON DATABASE relational_database FROM public;
+    REVOKE ALL ON DATABASE postgres FROM public;
+    REVOKE ALL ON DATABASE template0 FROM public;
+    REVOKE ALL ON DATABASE template1 FROM public;
+    GRANT CONNECT ON DATABASE relational_database TO rodzers;
+    GRANT CONNECT ON DATABASE relational_database TO dominik;
+    GRANT USAGE ON SCHEMA public TO rodzers;
+    GRANT USAGE ON SCHEMA public TO dominik;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO rodzers;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO dominik;
+EOSQL

--- a/relational_database/docker-compose.yaml
+++ b/relational_database/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:latest
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgrespassword
+      POSTGRES_DB: relational_database
+    ports:
+      - "5432:5432"
+    volumes:
+      # Mount a persistent volume to store the PostgreSQL data
+      - postgres-data:/var/lib/postgresql/data
+      # Mount the `create_tables.sql` script to the container
+      - ./create_tables.sql:/docker-entrypoint-initdb.d/create_tables.sql
+      # Mount the create_users.sh script to the container
+      - ./create_users.sh:/docker-entrypoint-initdb.d/init-user-db.sh
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
Did everything the issue requested.

Created a 'relational_database' directory, which contains the Docker-Compose file, the script for creating the table with an entry and a script for creating two users with limited access to said database/table.